### PR TITLE
hotfix: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To set up Legion AI, follow these steps:
    
 2. Navigate to the project directory:
    ```bash
-   cd legion-ai
+   cd LegionAI
    ```
 
 3. Install the necessary dependencies:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ scipy
 sympy
 qiskit
 pennylane
-brain2
+brian2
 torch
 transformers


### PR DESCRIPTION
The package name is misspelled: there is no `brain2` package on PyPI.  
The correct name of the neuronal simulator is **[brian2](https://pypi.org/project/brian2/)**.

Additionally, in the README, the directory name is incorrect. Instead of:  
```bash
cd legion-ai
```  
it should be:  
```bash
cd LegionAI
```

thanks